### PR TITLE
docs: withdraw the stale LLMKit listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Pomerium](https://github.com/pomerium/pomerium) - Open-source MCP gateway that secures access to your MCP servers with authentication and access policies, including per-tool controls.
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Enterprise MCP Gateway with federated search, secure sandbox execution, OAuth 2.1 proxy, and unified HTTP API. Self-hosted via Docker.
 - [Unla](https://github.com/AmoyLab/Unla) - MCP Gateway - A lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
+- [LLMKit](https://github.com/smigolsmigol/llmkit) - Open-source AI API gateway on Cloudflare Workers + Durable Objects. Cost tracking, atomic budget enforcement with reservation pattern, rate limiting, encrypted key vault. 11 providers, TypeScript/Python SDKs, CLI, MCP server with 11 tools. MIT licensed, runs on free tier.
 
 ## Commercial MCP Gateways
 


### PR DESCRIPTION
## Status

Withdrawn.

## Reason

The product surface and public setup changed after this PR was opened, so the listing text is no longer a current merge candidate.

No maintainer action is requested.