### PR TITLE
Add AIRIS MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 
 ## Open-source MCP Gateways
 - [agentgateway](https://github.com/agentgateway/agentgateway) - Next Generation Agentic Proxy for AI Agents and MCP servers that provides drop-in security, observability, and governance for agent-to-agent and agent-to-tool communication.
+- [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Reduces context tokens by 97% via progressive disclosure with auto-enable on demand, HOT/COLD server lifecycle, and circuit breaker.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker MCP CLI plugin / MCP Gateway.
 - [Gate22](https://github.com/aipotheosis-labs/gate22) - Open-source MCP gateway and control plane for teams to govern which tools agents can use, what they can do, and how it’s audited.
 - [hyper-mcp](https://github.com/tuananh/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly plugins.


### PR DESCRIPTION
## Summary

Adds [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) to the open-source MCP Gateways list.

## What is AIRIS MCP Gateway?

A Docker-based MCP multiplexer that aggregates 60+ tools from multiple MCP servers behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Key features:

- **97% context token reduction** via progressive disclosure — only 7 meta-tools are exposed instead of 60+
- **Dynamic MCP**: tools are discovered and executed on demand through `airis-find` → `airis-exec`
- **HOT/COLD server lifecycle**: HOT servers stay loaded, COLD servers start lazily and idle-kill after timeout
- **Auto-enable on demand**: disabled servers are automatically enabled when a tool is requested
- **Circuit breaker**: failing servers are isolated to prevent cascade failures
- **One-command Docker setup**: `docker compose up -d`

## Why it belongs here

AIRIS MCP Gateway solves the token explosion problem when connecting LLMs to many MCP servers. Instead of exposing all tools directly (42k+ tokens), it uses a progressive disclosure pattern to keep context minimal while maintaining access to the full toolset.