### PR TITLE
Add SidClaw to Open-source MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Obot](https://github.com/obot-platform/obot) - Open-source MCP Gateway and AI Platform.
 - [Open Edison](https://github.com/Edison-Watch/open-edison) - Open-source secure MCP Gateway and control panel with data exfiltration prevention, execution controls, fine-grained online configuration and visibility into agent interactions.
 - [Pomerium](https://github.com/pomerium/pomerium) - Open-source MCP gateway that secures access to your MCP servers with authentication and access policies, including per-tool controls.
+- [SidClaw](https://github.com/sidclawhq/platform) - Governance proxy for MCP servers with policy evaluation, human approval workflows, and hash-chain audit trails. 18+ framework integrations. Apache 2.0.
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Enterprise MCP Gateway with federated search, secure sandbox execution, OAuth 2.1 proxy, and unified HTTP API. Self-hosted via Docker.
 - [Unla](https://github.com/AmoyLab/Unla) - MCP Gateway - A lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
 


### PR DESCRIPTION
Adds [SidClaw](https://github.com/sidclawhq/platform) to the Open-source MCP Gateways section.

SidClaw is an open-source governance proxy for MCP servers. It sits between agents and MCP tool servers, evaluating every tool call against a policy engine before forwarding. Features include human approval workflows and hash-chain audit trails. 18+ framework integrations. Apache 2.0 licensed.

- GitHub: https://github.com/sidclawhq/platform
- Website: https://sidclaw.com
- Docs: https://docs.sidclaw.com

Entry placed alphabetically in the Open-source section.