### PR TITLE
Add EventTrader MCP Server — prediction market trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Ventil AI](https://ventil.ai) - Go Agent-Native Across Your Business.
 - [Webrix](https://webrix.ai) - Enterprise AI adoption infrastructure with secure MCP Gateway for connecting AI agents (Claude, Cursor, ChatGPT, Antigravity) to internal tools. Features SSO, RBAC, audit trails, and governance controls.
 - [Zuplo](https://zuplo.com/features/ai-gateway) - Zuplo's AI gateway is designed with federated self-serve for engineers, with hierarchical cost controls, guard rails, semantic caching, and more.
+
+- [EventTrader MCP Server](https://github.com/eventtrader/event-trader-mcp) — AI prediction market trading: place bets, TGE token price predictions, real-time orderbooks, AI agent cloning, due diligence scoring. Remote endpoint at `cymetica.com/.well-known/mcp.json`. [Platform](https://cymetica.com?utm_source=github&utm_medium=pr&utm_campaign=mcp-outreach) | [TGE Markets](https://cymetica.com/tge-launch?utm_source=github&utm_medium=pr&utm_campaign=mcp-outreach)


### PR DESCRIPTION
## What this adds

[EventTrader MCP Server](https://github.com/eventtrader/event-trader-mcp) — AI prediction market trading tools for Claude, ChatGPT, and other AI assistants.

### MCP Server Capabilities
- **Prediction market trading** — place bets on future events with on-chain settlement
- **Pre-launch TGE predictions** — predict Day-1 prices of tokens before they launch
- **Real-time market data** — orderbooks, prices, trade history for 9 CLOB pairs
- **AI agent cloning** — deploy copies of autonomous trading agents
- **AI due diligence** — score any company 0-100 for AI nativeness
- **Smart routing** — one endpoint, automatic routing to the right specialist

### Technical Details
- Remote MCP endpoint: `https://cymetica.com/.well-known/mcp.json`
- A2A Agent Card: `https://cymetica.com/.well-known/agent.json`
- Authentication: Bearer token or API key (free registration)
- Transport: HTTP/SSE

### Links
- MCP Server Repo: https://github.com/eventtrader/event-trader-mcp
- MCP Endpoint: https://cymetica.com/.well-known/mcp.json
- Platform: https://cymetica.com?utm_source=github&utm_medium=pr&utm_campaign=mcp-outreach
- TGE Markets: https://cymetica.com/tge-launch?utm_source=github&utm_medium=pr&utm_campaign=mcp-outreach
- Agent Card: https://cymetica.com/.well-known/agent.json
- API Docs: https://cymetica.com/api/docs