### PR TITLE
add authsome to Open-source list (credential broker for agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 200 stars and 2 contributors or more.
 
 - [agentgateway](https://github.com/agentgateway/agentgateway) - Next Generation Agentic Proxy for AI Agents and MCP servers that provides drop-in security, observability, and governance for agent-to-agent and agent-to-tool communication.
-- [authsome](https://github.com/manojbajaj95/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time so raw keys never enter the agent's environment. 30+ providers preconfigured (GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe, …). MIT.
+- [authsome](https://github.com/agentrhq/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time so raw keys never enter the agent's environment. 30+ providers preconfigured (GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe, …). MIT.
 - [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Reduces context tokens by 97% via progressive disclosure with auto-enable on demand, HOT/COLD server lifecycle, and circuit breaker.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker MCP CLI plugin / MCP Gateway.
 - [Gate22](https://github.com/aipotheosis-labs/gate22) - Open-source MCP gateway and control plane for teams to govern which tools agents can use, what they can do, and how it’s audited.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 200 stars and 2 contributors or more.
 
 - [agentgateway](https://github.com/agentgateway/agentgateway) - Next Generation Agentic Proxy for AI Agents and MCP servers that provides drop-in security, observability, and governance for agent-to-agent and agent-to-tool communication.
+- [authsome](https://github.com/manojbajaj95/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time so raw keys never enter the agent's environment. 30+ providers preconfigured (GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe, …). MIT.
 - [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Reduces context tokens by 97% via progressive disclosure with auto-enable on demand, HOT/COLD server lifecycle, and circuit breaker.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker MCP CLI plugin / MCP Gateway.
 - [Gate22](https://github.com/aipotheosis-labs/gate22) - Open-source MCP gateway and control plane for teams to govern which tools agents can use, what they can do, and how it’s audited.


### PR DESCRIPTION
hey, opening this to propose authsome under Open-source MCP Gateways.

upfront caveats:
- authsome is technically not an MCP gateway. it's a local OAuth2 and API-key credential broker for AI agents. it sits in the same "auth/credentials for agents" lane as Peta (already in your Commercial list as "1Password for AI Agents"), but as a local-first OSS CLI rather than a hosted MCP vault.
- it currently doesn't meet the "200 stars and 2 contributors" gate on the Open-source list. if that's a hard rule, please close. happy to resubmit when adoption catches up, or move to a different section.

what authsome does: login once via browser PKCE or device code, credentials live in an encrypted vault at ~/.authsome, a local HTTPS proxy injects them at request time so the agent's process env never holds raw keys. 30+ providers preconfigured (github, google, openai, linear, slack, notion, resend, stripe, etc). MIT, Python.

submitted in case the credential-broker tier alongside auth-focused gateways like Peta, Pomerium, and Jetski is worth representing in the open-source column.

repo: https://github.com/agentrhq/authsome
license: MIT
pypi: https://pypi.org/project/authsome/

i'm not the original author of authsome, i work alongside the team on distribution.