### PR TITLE
Add Dominion Observatory to Commercial MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Alpic](https://alpic.ai) - Alpic's all-in-one cloud platform provides the infrastructure and tools to turn your product into an AI-native experience.
 - [Arcade](https://www.arcade.dev) - Securely connect your AI to MCPs, APIs, data, and more.
 - [Dedalus Labs](https://www.dedaluslabs.ai) - Connect any LLM to any MCP server with a single API.
+- [Dominion Observatory](https://dominion-observatory.sgdata.workers.dev) - Behavioral trust scoring gateway for 14,820+ MCP servers. Routes agent traffic through trust verification with per-call attestation receipts, compliance reporting, and MiCA Article 12 audit trails.
 - [E2B](https://e2b.dev/docs/mcp) - Connect to 200+ tools through the Model Context Protocol.
 - [Golf](https://golf.dev) - Deploy production-ready, official MCP servers for your company.
 - [MCP Boss](https://www.mcp-boss.com) - The MCP Management Platform for Individuals and Teams.


### PR DESCRIPTION
Dominion Observatory provides behavioral trust scoring for 14,820+ MCP servers. It acts as a trust verification gateway with per-call attestation receipts, compliance reporting, and MiCA Article 12 audit trails.

Live: https://dominion-observatory.sgdata.workers.dev
GitHub: https://github.com/sgdata-io/dominion-observatory