### PR TITLE
Add The STALL — 209-capability data intelligence MCP with x402 micropayments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
+- [The STALL](https://the-stall.intuitek.ai) - 207-capability data intelligence MCP with per-call x402 micropayments. Financial markets, crypto, DeFi, options flow, macro, and real-world intelligence for AI agents — zero subscription required.
 - [ToolRouter](https://toolrouter.com) - Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, flight search, and more. One API key replaces managing dozens of provider accounts.
 - [TrueFoundry](https://www.truefoundry.com/mcp-gateway) - MCP Gateway – Secure Access to MCP Servers for Unified Integration.
 - [TurboMCP](https://turbomcp.ai) - Connect your apps to AI on your terms.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
-- [The STALL](https://the-stall.intuitek.ai) - 207-capability data intelligence MCP with per-call x402 micropayments. Financial markets, crypto, DeFi, options flow, macro, and real-world intelligence for AI agents — zero subscription required.
+- [The STALL](https://the-stall.intuitek.ai) - 209-capability data intelligence MCP with per-call x402 micropayments. Financial markets, crypto, DeFi, options flow, macro, and real-world intelligence for AI agents — zero subscription required.
 - [ToolRouter](https://toolrouter.com) - Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, flight search, and more. One API key replaces managing dozens of provider accounts.
 - [TrueFoundry](https://www.truefoundry.com/mcp-gateway) - MCP Gateway – Secure Access to MCP Servers for Unified Integration.
 - [TurboMCP](https://turbomcp.ai) - Connect your apps to AI on your terms.


### PR DESCRIPTION
## The STALL

**URL:** https://the-stall.intuitek.ai

**Category:** Commercial MCP Gateways

### What it does

The STALL is a 209-capability data intelligence MCP server with per-call x402 micropayments. AI agents connect once and get access to:

- **Financial markets:** stock prices/history, options chains, options flow (GEX), earnings, dividends, insider trades, ETF holdings
- **Crypto & DeFi:** token prices, on-chain data, DeFi protocols/yields, whale tracking, funding rates
- **Macro & policy:** Treasury yields, FOMC tracker, IMF outlooks, World Bank data, Fed contracts
- **Real-world intelligence:** weather, earthquakes, aviation weather, flight tracking, drug recalls, clinical trials, patents
- **Agent utilities:** web scraping, content analysis, social intelligence, domain lookup, IP intel

### Why it fits here

The STALL follows the same pattern as other Commercial MCP Gateways: agents connect via standard MCP protocol and get access to a wide range of capabilities in one endpoint. The differentiator is **x402 micropayment pricing** — agents pay per-call in USDC with no subscription required, making it suitable for cost-controlled autonomous agent workflows.

### Verification

```bash
curl https://the-stall.intuitek.ai/health
# Returns 210 capabilities with pricing metadata
```

Built by [IntuiTek¹](https://intuitek.ai).