### PR TITLE
Add VerditNxtGen — gateway-agnostic cryptographic sidecar proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Pomerium](https://github.com/pomerium/pomerium) - Open-source MCP gateway that secures access to your MCP servers with authentication and access policies, including per-tool controls.
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Enterprise MCP Gateway with federated search, secure sandbox execution, OAuth 2.1 proxy, and unified HTTP API. Self-hosted via Docker.
 - [Unla](https://github.com/AmoyLab/Unla) - MCP Gateway - A lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
-
+- [VerditNxtGen Sidecar Proxy](https://github.com/ShopFarnow/VerditNxtGen/tree/main/sdk/sidecar-proxy) — Transparent Docker sidecar that sits between any MCP gateway (IBM ContextForge, Docker MCP Gateway, Bifrost) and destination tools. Signs every request with HMAC-SHA256, logs telemetry asynchronously to the VerditNxtGen compliance ledger, and forwards traffic with zero latency overhead. Drop-in for SOC2 audit trails.
 ## Commercial MCP Gateways
 
 - [Alpic](https://alpic.ai) - Alpic's all-in-one cloud platform provides the infrastructure and tools to turn your product into an AI-native experience.


### PR DESCRIPTION
## Summary

Adds the VerditNxtGen Universal MCP Sidecar Proxy to the list.

## What it is

A lightweight, gateway-agnostic Docker container that intercepts MCP traffic
between any third-party gateway and destination tools — without modifying
application code.

**One docker-compose change to enable it:**

```yaml
services:
  verdit-sidecar:
    image: ghcr.io/shopfarnow/verditnxtgen-sidecar:latest
    environment:
      VERDIT_API_KEY: "${VERDIT_API_KEY}"
      DOWNSTREAM_URL: "http://your-mcp-tool:3000"
    ports:
      - "8080:8080"
```

Point your gateway at `http://verdit-sidecar:8080` instead of the tool directly.

**What it provides:**
- HMAC-SHA256 signature on every tool call (immutable proof-of-source)
- Async telemetry POST to `/api/v1/ingest/gateway-log` (non-blocking)
- SOC2 chain-of-custody manifest for each deployment
- Works with IBM ContextForge, Docker MCP Gateway, Bifrost, MCPX — any gateway

GitHub: https://github.com/ShopFarnow/VerditNxtGen
Sidecar source: https://github.com/ShopFarnow/VerditNxtGen/tree/main/sdk/sidecar-proxy