### PR TITLE
Add Proxygate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Onbox](https://onbox.ai) - Unified context for AI agents.
 - [Peta](https://peta.io) - 1Password for AI Agents : a self-hosted MCP vault + gateway (with HITL approvals)
 - [PolicyLayer](https://policylayer.com) - Hosted gateway for your MCP servers that applies deterministic rules to every tool call, outside the LLM reasoning loop, so your agents can only do what you allow.
+- [Proxygate](https://proxygate.ai) - Marketplace gateway where AI agents connect once (MCP, SDK, CLI, or REST API) and call any listing of real-world data APIs per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call.
 - [Rube](https://rube.composio.dev) - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion.
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.


### PR DESCRIPTION
Adds Proxygate. Curated marketplace of real-world data APIs for AI agents: connect once (MCP, SDK, CLI, or REST API) and call any listing per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call. Live in the official MCP Registry as ai.proxygate/mcp.