### PR TITLE
Add Toolport to Commercial MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
+- [Toolport](https://toolport.app) - Local-first MCP gateway that gives every AI client one shared, governed set of servers: lazy discovery for ~90% fewer tool tokens, tool-integrity checks against rug pulls and prompt-injection, and secrets kept in your OS keychain. Team plan adds shared config and org controls.
 - [ToolRouter](https://toolrouter.com) - Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, flight search, and more. One API key replaces managing dozens of provider accounts.
 - [TrueFoundry](https://www.truefoundry.com/mcp-gateway) - MCP Gateway – Secure Access to MCP Servers for Unified Integration.
 - [TurboMCP](https://turbomcp.ai) - Connect your apps to AI on your terms.


### PR DESCRIPTION
Adds **Toolport** to the Commercial MCP Gateways section (alphabetical).

Toolport is a local-first MCP gateway: set up an MCP server once and every AI client (Claude, Cursor, VS Code, Codex) shares it, with lazy discovery for ~90% fewer tool tokens, tool-integrity checks against rug pulls and prompt-injection, and secrets kept in the OS keychain. The free app is local-first; the commercial **Toolport for Teams** tier adds shared config and org governance, which is why I've placed it in the commercial section.

- Site: https://toolport.app
- Repo: https://github.com/tsouth89/toolport

Thanks for maintaining the list!