### PR TITLE
docs(readme): add UTM tracking to e2b.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Alpic](https://alpic.ai) - Alpic's all-in-one cloud platform provides the infrastructure and tools to turn your product into an AI-native experience.
 - [Arcade](https://www.arcade.dev) - Securely connect your AI to MCPs, APIs, data, and more.
 - [Dedalus Labs](https://www.dedaluslabs.ai) - Connect any LLM to any MCP server with a single API.
-- [E2B](https://e2b.dev/docs/mcp) - Connect to 200+ tools through the Model Context Protocol.
+- [E2B](https://e2b.dev/docs/mcp?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=awesome-mcp-gateways) - Connect to 200+ tools through the Model Context Protocol.
 - [Golf](https://golf.dev) - Deploy production-ready, official MCP servers for your company.
 - [MCP Boss](https://www.mcp-boss.com) - The MCP Management Platform for Individuals and Teams.
 - [MCP Manager](https://www.mcpmanager.ai) - The central control layer for MCP at scale, with granular access controls, end-to-end audit trails, and security guardrails.


### PR DESCRIPTION
Adds UTM parameters to the e2b.dev link(s) in the README so GitHub-referral traffic is attributed per repo.

`utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=<repo>`

Applies to apex e2b.dev links (root and subpaths). Subdomains and already-tagged links are untouched, and URL anchors are preserved.