### PR TITLE
Add Vaaya to Commercial MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [TrueFoundry](https://www.truefoundry.com/mcp-gateway) - MCP Gateway – Secure Access to MCP Servers for Unified Integration.
 - [TurboMCP](https://turbomcp.ai) - Connect your apps to AI on your terms.
 - [Unified Context Layer](https://ucl.dev/) - Unified Context Layer (UCL) is a multi-tenant Model Context Protocol (MCP) server that enables AI agents, automation platforms, and applications to connect to over 1,000 SaaS tools—such as Slack, Jira, Gmail, Shopify, Notion, and more—via a single standardized /command endpoint with little to no glue code needed.
+- [Vaaya](https://vaaya.ai) - Give your AI agent a prepaid card to pay per call for hundreds of paid services — web search & scraping, research, lead enrichment, media & video generation, code sandboxes, browser automation, and email — with no per-vendor signups or API keys.
 - [Ventil AI](https://ventil.ai) - Go Agent-Native Across Your Business.
 - [Webrix](https://webrix.ai) - Enterprise AI adoption infrastructure with secure MCP Gateway for connecting AI agents (Claude, Cursor, ChatGPT, Antigravity) to internal tools. Features SSO, RBAC, audit trails, and governance controls.
 - [Zuplo](https://zuplo.com/features/ai-gateway) - Zuplo's AI gateway is designed with federated self-serve for engineers, with hierarchical cost controls, guard rails, semantic caching, and more.


### PR DESCRIPTION
Adds [Vaaya](https://vaaya.ai) to **Commercial MCP Gateways**.

Vaaya is a remote MCP gateway (`https://vaaya.ai/mcp`) that gives an AI agent a prepaid card to pay per call for hundreds of paid services — search, research, lead enrichment, media & video generation, code sandboxes, browser automation, email — with no per-vendor signups or API keys. Published to the official MCP Registry as `ai.vaaya/mcp`. Inserted alphabetically.