### PR TITLE
Add SourceryKit to Commercial MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
+- [SourceryKit](https://github.com/ProvablyAI/sourcerykit) - Source-available Python SDK and hosted gateway that verifies an agent's outbound requests and MCP tool calls against a source of truth using zero-knowledge proofs, so a call only goes out if its claims check out; it also allow-lists trusted endpoints and logs every call. BSL 1.1.
 - [Toolport](https://toolport.app) - Local-first MCP gateway that gives every AI client one shared, governed set of servers: lazy discovery for ~90% fewer tool tokens, tool-integrity checks against rug pulls and prompt-injection, and secrets kept in your OS keychain. Team plan adds shared config and org controls.
 - [ToolRouter](https://toolrouter.com) - Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, flight search, and more. One API key replaces managing dozens of provider accounts.
 - [TrueFoundry](https://www.truefoundry.com/mcp-gateway) - MCP Gateway – Secure Access to MCP Servers for Unified Integration.


### PR DESCRIPTION
Hi, opened this to add SourceryKit to the Commercial MCP Gateways section, in alphabetical order between Smithery and Toolport.

SourceryKit is a source-available (BSL 1.1) Python SDK plus a hosted gateway that verifies an agent's outbound requests and MCP tool calls against a source of truth using zero-knowledge proofs, so a call only goes out if its claims check out. It also allow-lists trusted endpoints and logs every call. It sits close to PolicyLayer, applying checks to every tool call outside the model loop.

https://github.com/ProvablyAI/sourcerykit

Thanks for taking a look.
