### PR TITLE
Add SandBase to commercial MCP gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [PolicyLayer](https://policylayer.com) - Hosted gateway for your MCP servers that applies deterministic rules to every tool call, outside the LLM reasoning loop, so your agents can only do what you allow.
 - [Rube](https://rube.composio.dev) - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion.
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
+- [SandBase](https://github.com/sandbaseai/cli) - Connect AI coding agents to 2,000+ tools and 200+ models through one OAuth account and an ownership-aware local MCP bridge, using an open-source CLI.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
 - [Toolport](https://toolport.app) - Local-first MCP gateway that gives every AI client one shared, governed set of servers: lazy discovery for ~90% fewer tool tokens, tool-integrity checks against rug pulls and prompt-injection, and secrets kept in your OS keychain. Team plan adds shared config and org controls.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [PolicyLayer](https://policylayer.com) - Hosted gateway for your MCP servers that applies deterministic rules to every tool call, outside the LLM reasoning loop, so your agents can only do what you allow.
 - [Rube](https://rube.composio.dev) - Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion.
 - [Runlayer](https://www.runlayer.com) - The Simpler, Safer Way to Connect MCPs.
-- [SandBase](https://github.com/sandbaseai/cli) - Connect AI coding agents to 2,000+ tools and 200+ models through one OAuth account and an ownership-aware local MCP bridge, using an open-source CLI.
+- [SandBase](https://github.com/sandbaseai/cli) - Connect AI coding agents to 2,000+ AI models through one account and an ownership-aware local MCP bridge, using an open-source CLI.
 - [Scalekit](https://www.scalekit.com/agentic-actions) - A secure tool-calling layer for agents to act on behalf of users across external tools (Gmail, Calendar, Slack, Notion, etc.) with user-consented delegation and built-in token vaulting.
 - [Smithery](https://smithery.ai) - Your Agent's Gateway to the World.
 - [Toolport](https://toolport.app) - Local-first MCP gateway that gives every AI client one shared, governed set of servers: lazy discovery for ~90% fewer tool tokens, tool-integrity checks against rug pulls and prompt-injection, and secrets kept in your OS keychain. Team plan adds shared config and org controls.


### PR DESCRIPTION
## Summary

Adds SandBase to the **Commercial MCP Gateways** section. This is an official submission from the SandBase organization.

SandBase connects AI coding agents to 2,000+ AI models through one account. Its open-source CLI installs an ownership-aware local MCP bridge for supported clients.

The entry is intentionally placed under Commercial: the CLI is Apache-2.0, while it connects to the hosted SandBase platform. It is not being proposed for the Open-source section with its 200-Star / 2-contributor threshold.

## Validation

- Maintains alphabetical order between Runlayer and Scalekit
- One entry added
- `git diff --check` passes
- Repository URL is public and GitHub detects Apache-2.0

## Disclosure

I am affiliated with SandBase. AI assistance was used to prepare and review this contribution.
