### PR TITLE
Add SandBase Harness MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [Obot](https://github.com/obot-platform/obot) - Open-source MCP Gateway and AI Platform.
 - [Open Edison](https://github.com/Edison-Watch/open-edison) - Open-source secure MCP Gateway and control panel with data exfiltration prevention, execution controls, fine-grained online configuration and visibility into agent interactions.
 - [Pomerium](https://github.com/pomerium/pomerium) - Open-source MCP gateway that secures access to your MCP servers with authentication and access policies, including per-tool controls.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first MCP bridge that connects MCP clients to a self-hosted AI agent runtime, with persistent sessions, sandboxed tools, memory, credentials, audit logs, and replay.
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Enterprise MCP Gateway with federated search, secure sandbox execution, OAuth 2.1 proxy, and unified HTTP API. Self-hosted via Docker.
 - [Unla](https://github.com/AmoyLab/Unla) - MCP Gateway - A lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
 - [Wirken](https://github.com/gebruder/wirken) - The enterprise gateway for autonomous agents. Identity management, per-channel isolation, credential vault, per-session tamper-evident audit log.


### PR DESCRIPTION
## Summary
- add SandBase Harness to the open-source MCP gateway list
- describe its MCP client bridge to a self-hosted agent runtime
- mention persistent sessions, sandboxed tools, memory, credentials, audit, and replay

The entry is intentionally described as a bridge rather than claiming hosted gateway functionality. SandBase currently has 637 GitHub stars and 3 user contributors, meeting the list\x27s stated 200-star / 2-contributor threshold.