### PR TITLE
Add Helio to Open-source MCP Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Reduces context tokens by 97% via progressive disclosure with auto-enable on demand, HOT/COLD server lifecycle, and circuit breaker.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker MCP CLI plugin / MCP Gateway.
 - [Gate22](https://github.com/aipotheosis-labs/gate22) - Open-source MCP gateway and control plane for teams to govern which tools agents can use, what they can do, and how it’s audited.
+- [Helio](https://github.com/gethelio/helio) - Open-source governance proxy for MCP that sits between agents and the tools they call. Enforces policies, caps cumulative cross-tool spend across servers, routes approvals, checks evidence, and records an audit trail for every tool call, with no changes to agent code or MCP servers.
 - [hyper-mcp](https://github.com/tuananh/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly plugins.
 - [Jetski](https://github.com/hyprmcp/jetski) - Authentication, analytics, and prompt visibility for MCP servers with zero code changes. Supports OAuth2.1, DCR, real-time logs, and client onboarding out of the box.
 - [Klavis](https://github.com/Klavis-AI/klavis) - MCP integration platforms that let AI agents use tools reliably at any scale.


### PR DESCRIPTION
Adds [Helio](https://github.com/gethelio/helio) to the Open-source MCP Gateways section.

Helio is an Apache-2.0 governance proxy that sits between MCP clients and MCP servers. Every tool call passes through it, so you get policy enforcement, cumulative spend budgets that span multiple servers, approval routing, evidence checks, and an audit trail, without changing agent code or the MCP servers themselves. It installs as a single npm package (`npx @gethelio/proxy init`) that ships the proxy runtime and the dashboard UI together.

The entry is placed alphabetically between Gate22 and hyper-mcp, and `scripts/sort-readme.py` reports the file as already sorted.

One thing worth flagging up front: the section calls for 200 stars and 2 contributors or more, and Helio is not there yet. It sits at 10 stars and 1 contributor today. I did not want to submit it without saying so, so close this if it is too early and I will resubmit once it clears the bar.
