### PR TITLE
Add FLUJO to open-source MCP gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A list of awesome MCP Gateway Products. [Open a pull request](https://github.com
 - [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools (find, exec, schema, suggest, route, confidence, repo-index). Reduces context tokens by 97% via progressive disclosure with auto-enable on demand, HOT/COLD server lifecycle, and circuit breaker.
 - [Bifrost](https://github.com/maximhq/bifrost) - Open-source AI gateway with MCP support, provider routing, automatic failover, load balancing, and observability.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker MCP CLI plugin / MCP Gateway.
+- [FLUJO](https://github.com/mario-andreschak/FLUJO) - Local-first MCP client and visual agent builder that re-exposes configured MCP servers to other clients over Streamable HTTP, with centralized server configuration, encrypted credentials, and a web UI for inspecting tools, resources, and prompts.
 - [Gate22](https://github.com/aipotheosis-labs/gate22) - Open-source MCP gateway and control plane for teams to govern which tools agents can use, what they can do, and how it’s audited.
 - [hyper-mcp](https://github.com/tuananh/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly plugins.
 - [Jetski](https://github.com/hyprmcp/jetski) - Authentication, analytics, and prompt visibility for MCP servers with zero code changes. Supports OAuth2.1, DCR, real-time logs, and client onboarding out of the box.


### PR DESCRIPTION
Adds FLUJO under Open-source MCP Gateways, between Docker MCP Gateway and Gate22. FLUJO is a local-first MCP client and visual agent builder with a built-in proxy that re-exposes configured MCP servers over Streamable HTTP to other clients, alongside centralized server configuration and encrypted credentials.

Evidence:
- [README: FLUJO as an MCP proxy](https://github.com/mario-andreschak/FLUJO#-connected-apps-mcp)
- [MCP implementation](https://github.com/mario-andreschak/FLUJO/tree/main/src/backend/services/mcp)
- [MIT license](https://github.com/mario-andreschak/FLUJO/blob/main/LICENSE)
- [Contributors](https://github.com/mario-andreschak/FLUJO/graphs/contributors)

At submission the repository has 619 stars and more than 2 contributors, meeting the stated inclusion threshold. Checked for duplicate entries and submissions; `git diff --check` passed.